### PR TITLE
Bump async-openai to 0.20.0 and update library to work with it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ rust-version = "1.72.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-openai = { version = "0.12.2", default-features = false }
+async-openai = { version = "0.20.0", default-features = false }
 indxvec = { version = "1.9.0", default-features = false }
 log = { version = "0.4.21", default-features = false }
 tiktoken-rs = { version = "0.5.8", default-features = false }
 
 [dev-dependencies]
-async-openai = "0.12.2"
+async-openai = "0.20.0"
 tokio = "1.37.0"

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -1,7 +1,9 @@
 use std::error::Error;
 
+use async_openai::types::ChatCompletionRequestAssistantMessageArgs;
 use async_openai::types::ChatCompletionRequestMessage;
-use async_openai::types::ChatCompletionRequestMessageArgs;
+use async_openai::types::ChatCompletionRequestSystemMessageArgs;
+use async_openai::types::ChatCompletionRequestUserMessageArgs;
 use async_openai::types::CreateChatCompletionRequestArgs;
 use async_openai::types::Role;
 use async_openai::Client;
@@ -16,10 +18,11 @@ const MAX_MESSAGES: usize = 16;
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut stored_messages = get_stored_messages()?;
     stored_messages.push(
-        ChatCompletionRequestMessageArgs::default()
+        ChatCompletionRequestUserMessageArgs::default()
             .role(Role::User)
             .content("Where was it played?")
-            .build()?,
+            .build()?
+            .into(),
     );
     assert!(stored_messages.len() > MAX_MESSAGES);
 
@@ -28,10 +31,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .max_messages(MAX_MESSAGES)
         .split(&stored_messages);
 
-    let mut messages = vec![ChatCompletionRequestMessageArgs::default()
+    let mut messages = vec![ChatCompletionRequestSystemMessageArgs::default()
         .role(Role::System)
         .content("You are a helpful assistant.")
-        .build()?];
+        .build()?
+        .into()];
     messages.extend(recent_messages.iter().cloned());
     assert!(messages.len() <= MAX_MESSAGES + 1);
 
@@ -61,14 +65,16 @@ fn get_stored_messages() -> Result<Vec<ChatCompletionRequestMessage>, Box<dyn Er
     let mut messages = Vec::new();
     for _ in 0..2000 {
         messages.extend([
-            ChatCompletionRequestMessageArgs::default()
+            ChatCompletionRequestUserMessageArgs::default()
                 .role(Role::User)
                 .content("Who won the world series in 2020?")
-                .build()?,
-            ChatCompletionRequestMessageArgs::default()
+                .build()?
+                .into(),
+            ChatCompletionRequestAssistantMessageArgs::default()
                 .role(Role::Assistant)
                 .content("The Los Angeles Dodgers won the World Series in 2020.")
-                .build()?,
+                .build()?
+                .into(),
         ]);
     }
     Ok(messages)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,9 @@ impl IntoChatCompletionRequestMessage for async_openai::types::ChatCompletionReq
                     name: Some(message.name),
                 }
             }
-            role => panic!("unsupported role '{role:?}'"),
+            role @ async_openai::types::ChatCompletionRequestMessage::Tool(_) => {
+                panic!("unsupported role '{role:?}'")
+            }
         }
     }
 
@@ -490,7 +492,7 @@ impl IntoChatCompletionRequestMessage for async_openai::types::ChatCompletionRes
                     },
                 )
             }
-            role => panic!("unsupported role '{role:?}'"),
+            role @ async_openai::types::Role::Tool => panic!("unsupported role '{role}'"),
         }
     }
 }


### PR DESCRIPTION
This is a minimal working solution, i.e., it still makes use of the deprecated "function calls" on the async-openai side.